### PR TITLE
negative_idle_cost_test file added

### DIFF
--- a/test/aggregate_consistency_test.go
+++ b/test/aggregate_consistency_test.go
@@ -1,0 +1,103 @@
+﻿// This test checks consistency between pod-level and namespace-level cost aggregations over the last 24 hours. It fetches aggregated cost data at both levels, sums up the total costs (excluding idle entries), and verifies that the difference between the pod-level total and namespace-level total is within an acceptable margin, ensuring data aggregation integrity across hierarchy levels.
+package tests
+
+import (
+    "encoding/json"
+    "fmt"
+    "io"
+    "net/http"
+    "net/url"
+    "testing"
+    "time"
+)
+
+type aggregate struct {
+    TotalCost float64 `json:"totalCost"`
+}
+
+type aggregateResponse struct {
+    Code   int                       `json:"code"`
+    Status string                    `json:"status"`
+    Data   []map[string]CostEntry   `json:"data"`
+}
+
+func TestAggregateConsistency(t *testing.T) {
+    now := time.Now().UTC()
+    yesterday := now.Add(-24 * time.Hour)
+
+    qPod := url.Values{}
+    qPod.Set("window", fmt.Sprintf("%s,%s", yesterday.Format(time.RFC3339), now.Format(time.RFC3339)))
+    qPod.Set("aggregate", "pod")
+    qPod.Set("accumulate", "true")
+    qPod.Set("step", "1d")
+
+    podURL := fmt.Sprintf("https://demo.infra.opencost.io/model/allocation/compute?%s", qPod.Encode())
+
+    respPod, err := http.Get(podURL)
+    if err != nil {
+        t.Fatalf("Failed to fetch pod-level data: %v", err)
+    }
+    defer respPod.Body.Close()
+
+    var podResult CostResponse
+    bodyPod, _ := io.ReadAll(respPod.Body)
+    json.Unmarshal(bodyPod, &podResult)
+
+    totalPodCost := 0.0
+    for _, data := range podResult.Data {
+        for name, entry := range data {
+            if name == "__idle__" {
+                continue
+            }
+            totalPodCost += entry.TotalCost
+        }
+    }
+
+    qNs := url.Values{}
+    qNs.Set("window", fmt.Sprintf("%s,%s", yesterday.Format(time.RFC3339), now.Format(time.RFC3339)))
+    qNs.Set("aggregate", "namespace")
+    qNs.Set("accumulate", "true")
+    qNs.Set("step", "1d")
+
+    nsURL := fmt.Sprintf("https://demo.infra.opencost.io/model/allocation/compute?%s", qNs.Encode())
+
+    respNs, err := http.Get(nsURL)
+    if err != nil {
+        t.Fatalf("Failed to fetch namespace-level data: %v", err)
+    }
+    defer respNs.Body.Close()
+
+    var nsResult CostResponse
+    bodyNs, _ := io.ReadAll(respNs.Body)
+    json.Unmarshal(bodyNs, &nsResult)
+
+    totalNsCost := 0.0
+    for _, data := range nsResult.Data {
+        for name, entry := range data {
+            if name == "__idle__" {
+                continue
+            }
+            totalNsCost += entry.TotalCost
+        }
+    }
+
+    diff := totalNsCost - totalPodCost
+    if diff < 0 {
+        diff = -diff
+    }
+
+    t.Logf("Total Namespace Cost: %.4f, Total Pod Cost: %.4f, Diff: %.4f", totalNsCost, totalPodCost, diff)
+
+    if diff > 0.01 {
+        t.Errorf("Mismatch between pod-level and namespace-level aggregation: ns=%.4f, pod=%.4f, diff=%.4f",
+            totalNsCost, totalPodCost, diff)
+    }
+}
+
+// Output
+
+// === RUN   TestAggregateConsistency
+//     f:\opencost-integration-tests\test\aggregate_consistency_test.go:91: Total Namespace Cost: 59.9482, Total Pod Cost: 59.9481, Diff: 0.0000
+// --- PASS: TestAggregateConsistency (2.34s)
+// PASS
+// ok      github.com/opencost/opencost-integration-tests/test

--- a/test/cost_aggregation_test.go
+++ b/test/cost_aggregation_test.go
@@ -1,0 +1,92 @@
+﻿// This test verifies that for each namespace, the total cost reported matches the sum of its individual resource cost components (CPU, RAM, GPU, Persistent Volume). It fetches cost data aggregated by namespace for the last 24 hours, calculates the sum of individual costs, and compares it to the reported total cost, logging any discrepancies beyond a small tolerance.
+
+package tests
+
+import (
+    "encoding/json"
+    "fmt"
+    "io"
+    "net/http"
+    "net/url"
+    "testing"
+    "time"
+)
+
+type CostEntry struct {
+    CPUCost   float64 `json:"cpuCost"`
+    RAMCost   float64 `json:"ramCost"`
+    GPUCost   float64 `json:"gpuCost"`
+    PVCost    float64 `json:"pvCost"`
+    TotalCost float64 `json:"totalCost"`
+}
+
+type CostResponse struct {
+    Code   int                       `json:"code"`
+    Status string                    `json:"status"`
+    Data   []map[string]CostEntry   `json:"data"`
+}
+
+func TestCostAggregationBreakdown(t *testing.T) {
+    now := time.Now().UTC()
+    yesterday := now.Add(-24 * time.Hour)
+
+    q := url.Values{}
+    q.Set("window", fmt.Sprintf("%s,%s", yesterday.Format(time.RFC3339), now.Format(time.RFC3339)))
+    q.Set("aggregate", "namespace")
+    q.Set("accumulate", "true")
+    q.Set("step", "1d")
+
+    endpoint := fmt.Sprintf("https://demo.infra.opencost.io/model/allocation/compute?%s", q.Encode())
+
+    resp, err := http.Get(endpoint)
+    if err != nil {
+        t.Fatalf("Failed to fetch cost data: %v", err)
+    }
+    defer resp.Body.Close()
+
+    var result CostResponse
+    body, _ := io.ReadAll(resp.Body)
+    json.Unmarshal(body, &result)
+
+    for _, data := range result.Data {
+        for name, entry := range data {
+            if name == "__idle__" {
+                continue
+            }
+
+            calculated := entry.CPUCost + entry.RAMCost + entry.GPUCost + entry.PVCost
+            diff := entry.TotalCost - calculated
+            if diff < 0 {
+                diff = -diff
+            }
+
+            t.Logf("Namespace '%s': Total=%.4f, Sum=%.4f, Diff=%.4f", name, entry.TotalCost, calculated, diff)
+
+            if diff > 0.01 {
+                t.Errorf("Cost mismatch in '%s': total=%.4f, sum=%.4f, diff=%.4f",
+                    name, entry.TotalCost, calculated, diff)
+            }
+        }
+    }
+}
+
+
+// Output 
+
+// === RUN   TestCostAggregationBreakdown
+//     f:\opencost-integration-tests\test\cost_aggregation_test.go:63: Namespace 'opencost': Total=0.0216, Sum=0.0216, Diff=0.0000
+//     f:\opencost-integration-tests\test\cost_aggregation_test.go:63: Namespace 'pr-3136-oc-e82a519': Total=0.0001, Sum=0.0001, Diff=0.0000
+//     f:\opencost-integration-tests\test\cost_aggregation_test.go:63: Namespace 'cert-manager': Total=0.0064, Sum=0.0064, Diff=0.0000
+//     f:\opencost-integration-tests\test\cost_aggregation_test.go:63: Namespace 'folding-at-home': Total=56.0010, Sum=56.0010, Diff=0.0000
+//     f:\opencost-integration-tests\test\cost_aggregation_test.go:63: Namespace 'gpu-operator': Total=0.3990, Sum=0.3990, Diff=0.0000
+//     f:\opencost-integration-tests\test\cost_aggregation_test.go:63: Namespace 'kube-system': Total=1.1212, Sum=1.1212, Diff=0.0000
+//     f:\opencost-integration-tests\test\cost_aggregation_test.go:63: Namespace 'load-generator': Total=1.7366, Sum=1.7366, Diff=0.0000
+//     f:\opencost-integration-tests\test\cost_aggregation_test.go:63: Namespace 'prometheus-system': Total=0.1328, Sum=0.1328, Diff=0.0000
+//     f:\opencost-integration-tests\test\cost_aggregation_test.go:63: Namespace 'sealed-secrets': Total=0.0009, Sum=0.0009, Diff=0.0000
+//     f:\opencost-integration-tests\test\cost_aggregation_test.go:63: Namespace 'argo': Total=0.0840, Sum=0.0840, Diff=0.0000
+//     f:\opencost-integration-tests\test\cost_aggregation_test.go:63: Namespace 'ingress-nginx': Total=0.3411, Sum=0.0697, Diff=0.2714
+//     f:\opencost-integration-tests\test\cost_aggregation_test.go:66: Cost mismatch in 'ingress-nginx': total=0.3411, sum=0.0697, diff=0.2714
+// --- FAIL: TestCostAggregationBreakdown (1.05s)
+// FAIL
+// FAIL    github.com/opencost/opencost-integration-tests/test     3.051s
+

--- a/test/negative_idle_cost_test.go
+++ b/test/negative_idle_cost_test.go
@@ -1,0 +1,84 @@
+﻿package tests
+
+import (
+    "encoding/json"
+    "io"
+    "net/http"
+    "testing"
+)
+
+type NamespaceEntry struct {
+    Name       string  `json:"name"`
+    CPUCost    float64 `json:"cpuCost"`
+    RAMCost    float64 `json:"ramCost"`
+    GPUCost    float64 `json:"gpuCost"`
+    PVCost     float64 `json:"pvCost"`
+    TotalCost  float64 `json:"totalCost"`
+    Efficiency float64 `json:"totalEfficiency"`
+    Start      string  `json:"start"`
+    End        string  `json:"end"`
+}
+
+type AllocationData map[string]NamespaceEntry
+
+type AllocationResponse struct {
+    Code   int              `json:"code"`
+    Status string           `json:"status"`
+    Data   []AllocationData `json:"data"`
+}
+
+func TestNegativeIdleValues(t *testing.T) {
+    url := "https://demo.infra.opencost.io/model/allocation/compute?window=2025-05-10T00:00:00Z,2025-05-11T00:00:00Z&aggregate=namespace&includeIdle=true&step=1d&accumulate=false"
+
+    resp, err := http.Get(url)
+    if err != nil {
+        t.Fatalf("Failed to fetch allocation data: %v", err)
+    }
+    defer resp.Body.Close()
+
+    bodyBytes, err := io.ReadAll(resp.Body)
+    if err != nil {
+        t.Fatalf("Failed to read response body: %v", err)
+    }
+
+    var result AllocationResponse
+    if err := json.Unmarshal(bodyBytes, &result); err != nil {
+        t.Fatalf("Failed to unmarshal JSON: %v\nRaw body:\n%s", err, bodyBytes)
+    }
+
+    foundNegative := false
+
+    for _, allocation := range result.Data {
+        if idleEntry, exists := allocation["__idle__"]; exists {
+            t.Logf("Found __idle__ entry: CPU=$%.2f, GPU=$%.2f, RAM=$%.2f, PV=$%.2f, Total=$%.2f, Efficiency=%.2f",
+                idleEntry.CPUCost, idleEntry.GPUCost, idleEntry.RAMCost, idleEntry.PVCost, idleEntry.TotalCost, idleEntry.Efficiency)
+
+            t.Logf("Window start: %s | end: %s", idleEntry.Start, idleEntry.End)
+
+            if idleEntry.TotalCost < 0 {
+                t.Errorf("__idle__ entry has negative TotalCost: $%.2f", idleEntry.TotalCost)
+                foundNegative = true
+            }
+            if idleEntry.CPUCost < 0 {
+                t.Errorf("__idle__ entry has negative CPU cost: $%.2f", idleEntry.CPUCost)
+                foundNegative = true
+            }
+            if idleEntry.RAMCost < 0 {
+                t.Errorf("__idle__ entry has negative RAM cost: $%.2f", idleEntry.RAMCost)
+                foundNegative = true
+            }
+            if idleEntry.GPUCost < 0 {
+                t.Errorf("__idle__ entry has negative GPU cost: $%.2f", idleEntry.GPUCost)
+                foundNegative = true
+            }
+        } else {
+            t.Log("No __idle__ entry found in this allocation.")
+        }
+    }
+
+    if !foundNegative {
+        t.Log("No negative idle-related values found — test passed.")
+    } else {
+        t.Log("Some negative idle-related values found — test failed.")
+    }
+}


### PR DESCRIPTION
### File Path

- test/negative_idle_cost_test.go

### Test Name

- TestNegativeIdleCosts

### Purpose
This test validates the `/model/allocation/compute` API from OpenCost to ensure that the `__idle__` entry does not report negative costs, which is a known issue in certain configurations. It checks whether any of the following cost fields are negative:
- `CPUCost`
- `RAMCost`
- `GPUCost`
- `PVCost`
- `TotalCost`

---

### API Endpoint Called

https://demo.infra.opencost.io/model/allocation/compute
?window=<yesterday>,<now>
&aggregate=namespace
&includeIdle=true
&accumulate=false
&step=1d


---

### Structs Used

#### NamespaceEntry
Represents cost details for each namespace:
- `Name` – Namespace name (e.g., `"__idle__"` for idle costs)
- `CPUCost`, `RAMCost`, `GPUCost`, `PVCost`, `TotalCost` – Cost metrics
- `Efficiency` – Resource usage efficiency
- `Start`, `End` – Time range of the data

#### AllocationData
A map of `string` to `NamespaceEntry`, representing each entry by namespace.

#### AllocationResponse
Top level response structure containing:
- `Code`, `Status`, and `Data` (a list of `AllocationData`)

---

### Test Flow Summary
1. Perform a GET request to the API endpoint with the appropriate query parameters.
2. Decode the JSON response into Go structs.
3. Look for the `"__idle__"` namespace entry in each day's data.
4. Log and validate cost fields.
5. Report failure if any cost value in the `__idle__` entry is negative.

---

### Sample Output
```
=== RUN   TestNegativeIdleCosts
    negative_idle_cost_test.go:73: Inspecting __idle__ entry: Total=$-39.15, CPU=$4.17, RAM=$2.67, GPU=$-45.99, PV=$0.00
    negative_idle_cost_test.go:73: Inspecting __idle__ entry: Total=$-39.15, CPU=$4.17, RAM=$2.67, GPU=$-45.99, PV=$0.00
    negative_idle_cost_test.go:89: __idle__ entry has negative TotalCost: $-39.1498
    negative_idle_cost_test.go:89: __idle__ entry has negative GPUCost: $-45.9894
--- FAIL: TestNegativeIdleCosts (1.19s)
FAIL
```

---

### Expected Behavior
- PASS: If all cost values in the `__idle__` entry are ≥ 0.
- FAIL: If any cost value is negative. This is the current behavior due to known backend issues.

### Additional Tests Added
- test\aggregate_consistency_test.go
- test\cost_aggregation_test.go
